### PR TITLE
Corrección en la función de transformación de los geojsons

### DIFF
--- a/src/util/transformCoords.js
+++ b/src/util/transformCoords.js
@@ -7,19 +7,22 @@ const proj4 = require("proj4");
  * @returns {Object} Objeto con las coordenadas de las parcelas cambiadas
  */
 const transformCoords = (geojson, projection) => {
-    const transformed = geojson.features.map((feature) => {
-        return {
-            ...feature,
-            geometry: {
-                ...feature.geometry,
-                coordinates: feature.geometry.coordinates.map(subpolygon => subpolygon.map(pair => {
-                    const firstProjection = 'PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs"],AUTHORITY["EPSG","3857"]]';
-                    const secondProjection = proj4.defs(projection);
-                    return proj4(firstProjection, secondProjection, pair);
-                }))
+    const result = {
+        ...geojson,
+        features: geojson.features.map((feature) => {
+            return {
+                ...feature,
+                geometry: {
+                    ...feature.geometry,
+                    coordinates: feature.geometry.coordinates.map(subpolygon => subpolygon.map(pair => {
+                        const firstProjection = 'PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs"],AUTHORITY["EPSG","3857"]]';
+                        const secondProjection = proj4.defs(projection);
+                        return proj4(firstProjection, secondProjection, pair);
+                    }))
+                }
             }
-        }
-    });
-    return transformed;
+        })
+    }
+    return result;
 }
 module.exports = transformCoords;

--- a/src/util/transformCoords.js
+++ b/src/util/transformCoords.js
@@ -7,14 +7,19 @@ const proj4 = require("proj4");
  * @returns {Object} Objeto con las coordenadas de las parcelas cambiadas
  */
 const transformCoords = (geojson, projection) => {
-     geojson.features.map( (feature) => {
-          for (let key in feature.geometry.coordinates[0]) {
-               let firstProjection = 'PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs"],AUTHORITY["EPSG","3857"]]';
-               let secondProjection = proj4.defs(projection);
-               feature.geometry.coordinates[0][key] = proj4(firstProjection, secondProjection, feature.geometry.coordinates[0][key]);
-          }
-          return feature;
-     });
-     return geojson;
+    const transformed = geojson.features.map((feature) => {
+        return {
+            ...feature,
+            geometry: {
+                ...feature.geometry,
+                coordinates: feature.geometry.coordinates.map(subpolygon => subpolygon.map(pair => {
+                    const firstProjection = 'PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs"],AUTHORITY["EPSG","3857"]]';
+                    const secondProjection = proj4.defs(projection);
+                    return proj4(firstProjection, secondProjection, pair);
+                }))
+            }
+        }
+    });
+    return transformed;
 }
 module.exports = transformCoords;


### PR DESCRIPTION
Hola! 

Trabajando con esta librería me di cuenta de que la función de transformación de las coordenadas sólo transforma el primer array dentro del atributo coordinates de cada feature. No sé si esto era intencionado pero por si acaso he actualizado la función para que transforme todos los subarrays.

Dime qué te parece. Un saludo!